### PR TITLE
All bidding features needed for first round of bidding 

### DIFF
--- a/service/src/main/java/com/chabomakers/nico/controllers/GameStateResponse.java
+++ b/service/src/main/java/com/chabomakers/nico/controllers/GameStateResponse.java
@@ -21,6 +21,8 @@ public interface GameStateResponse {
 
   Map<UUID, List<PowerPlantCard>> userPowerPlants();
 
+  Map<UUID, Integer> userMoney();
+
   Integer gameRound();
 
   @Nullable

--- a/service/src/main/java/com/chabomakers/nico/controllers/GameStateResponse.java
+++ b/service/src/main/java/com/chabomakers/nico/controllers/GameStateResponse.java
@@ -21,6 +21,8 @@ public interface GameStateResponse {
 
   Map<UUID, List<PowerPlantCard>> userPowerPlants();
 
+  Integer gameRound();
+
   @Nullable
   UUID currentUser();
 

--- a/service/src/main/java/com/chabomakers/nico/gamestate/GameStateMachine.java
+++ b/service/src/main/java/com/chabomakers/nico/gamestate/GameStateMachine.java
@@ -26,6 +26,15 @@ import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Handles state manipulation and game actions.
+ *
+ * Mostly handles bidding. Additional rules not yet implemented:
+ * 1. A user cannot have more than 3 power plants. If they buy a forth they need to discard one.
+ * 2. If no one buys a single power plant card in a game round, then we should
+ *    discard the lowest power plant.
+ * 3. We don't do anything special to determine player order before bidding.
+ */
 @Singleton
 public class GameStateMachine {
 
@@ -70,10 +79,11 @@ public class GameStateMachine {
         if (currentBidPlant != null) {
           throw new BadRequestException("Choosing a plant when a plant is already chosen.");
         }
-        if (action.bid() == null) {
+        Integer currentBid = action.bid();
+        if (currentBid == null) {
           throw new BadRequestException("Bid value cannot be null when submitting a bid.");
         }
-        validateBid(action.userId(), action.bid());
+        validateBid(action.userId(), currentBid);
         currentPowerPlantBid = action.bid();
         highestBidUser = action.userId();
         currentBidPlant = powerPlantMarket.getCard(action.choosePlantId());
@@ -86,7 +96,7 @@ public class GameStateMachine {
         if (gameRound == 0) {
           throw new BadRequestException("Cannot pass during a user's first AUCTION_PICK_PLANT.");
         }
-        // TODO: test this case.
+        // TODO: test this case once we have a test that can complete an entire game round.
         selectNextBidUser();
       } else {
         throw new BadRequestException("Can only pass or choose plant during this phase.");

--- a/service/src/test/java/com/chabomakers/nico/GameStateMachineIntegrationTest.java
+++ b/service/src/test/java/com/chabomakers/nico/GameStateMachineIntegrationTest.java
@@ -70,6 +70,9 @@ public class GameStateMachineIntegrationTest {
     Assertions.assertEquals(gameStateMachine.gameState().currentUser(), player2Id);
     Assertions.assertEquals(gameStateMachine.gameState().userWithHighestPowerplantBid(), player1Id);
     Truth.assertThat(gameStateMachine.gameState().usersPassedFromBidding()).containsExactly();
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player1Id)).isEqualTo(50);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player2Id)).isEqualTo(50);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player3Id)).isEqualTo(50);
 
     auctionAction =
         ImmutableAuctionAction.builder().actionType(ActionType.PASS).userId(player2Id).build();
@@ -82,6 +85,9 @@ public class GameStateMachineIntegrationTest {
     auctionAction =
         ImmutableAuctionAction.builder().actionType(ActionType.PASS).userId(player3Id).build();
     gameStateMachine.performAuctionAction(auctionAction);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player1Id)).isEqualTo(45);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player2Id)).isEqualTo(50);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player3Id)).isEqualTo(50);
 
     // Since both users passed, we are now onto the phase where the second user gets to
     // choose a plant to begin bidding on.
@@ -106,6 +112,9 @@ public class GameStateMachineIntegrationTest {
             .build();
     gameStateMachine.performAuctionAction(auctionAction);
     Truth.assertThat(gameStateMachine.gameState().currentUser()).isEqualTo(player3Id);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player1Id)).isEqualTo(45);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player2Id)).isEqualTo(50);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player3Id)).isEqualTo(50);
 
     auctionAction =
         ImmutableAuctionAction.builder().actionType(ActionType.PASS).userId(player3Id).build();
@@ -118,6 +127,9 @@ public class GameStateMachineIntegrationTest {
     Truth.assertThat(gameStateMachine.gameState().gamePhase())
         .isEqualTo(GamePhase.AUCTION_PICK_PLANT);
     Truth.assertThat(userPowerPlants.get(player2Id)).containsExactly(secondPowerPlant);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player1Id)).isEqualTo(45);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player2Id)).isEqualTo(38);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player3Id)).isEqualTo(50);
 
     //
     // THIRD USER INITIATES AUCTION ON A PLANT AND WINS AUTOMATICALLY
@@ -128,7 +140,7 @@ public class GameStateMachineIntegrationTest {
             .actionType(ActionType.CHOOSE_PLANT)
             .choosePlantId(auctionedPowerPLant.id())
             .userId(player3Id)
-            .bid(12)
+            .bid(13)
             .build();
     gameStateMachine.performAuctionAction(auctionAction);
 
@@ -137,6 +149,9 @@ public class GameStateMachineIntegrationTest {
     Truth.assertThat(gameState.gamePhase()).isEqualTo(GamePhase.BUYING_RESOURCES);
     userPowerPlants = gameState.userPowerPlants();
     Truth.assertThat(userPowerPlants.get(player3Id)).containsExactly(auctionedPowerPLant);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player1Id)).isEqualTo(45);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player2Id)).isEqualTo(38);
+    Truth.assertThat(gameStateMachine.gameState().userMoney().get(player3Id)).isEqualTo(37);
   }
 
   @Test


### PR DESCRIPTION
Three diffs related to the bidding phase of the game. Once landed, all features needed for the game's first round of bidding are complete. A few additional features will need to be added to support the bidding phrase in later game rounds. I'll loop back on this later. 

As implemented in this diff, the frontend client needs to do some basic interpretation to decide when some buttons don't apply (ie, in gamephase 1 during `AUCTION_PICK_PLANT` phase a player cannot perform any `PASS` action). Right now the backend doesn't provide the frontend any hint about this. If we think it is easier, we can change the backend to give the frontend more hints.

_It will be easier to look at the following commits individually, instead of looking at the total files changed_

----

Commit 1: if a user doesn't win a power plant that they initiate bidding for, they are given a second chance to start bidding on a power plant of their choice.

Commit 2: Add & track currency. Put it in another map instead of nesting in the User object. Why? Because this was marginally easier for me. Feel free to move all user related fields in a unified user object on the frontend. Also noticed use of the `synchronized` keyword. This prevents race conditions in the `StateMachine` class. This needs to be on every public method.

Commit 3: Improve comments.