### PR TITLE
Don't allow a user to start an auction if they already won a previous auction

### DIFF
--- a/service/src/test/java/com/chabomakers/nico/GameStateMachineIntegrationTest.java
+++ b/service/src/test/java/com/chabomakers/nico/GameStateMachineIntegrationTest.java
@@ -319,7 +319,8 @@ public class GameStateMachineIntegrationTest {
         gameStateMachine.gameState().userPowerPlants();
     Assertions.assertEquals(userPowerPlants.get(player2Id).size(), 1);
 
-    // Verify: player 1 gets to start a new auction, since this is round 1.
+    // Verify: player 1 gets to start a new auction, since this is round 1 and
+    // they lost their last auction.
     gameStateResponse = gameStateMachine.gameState();
     Assertions.assertEquals(gameStateResponse.currentUser(), player1Id);
   }

--- a/service/src/test/java/com/chabomakers/nico/GameStateMachineIntegrationTest.java
+++ b/service/src/test/java/com/chabomakers/nico/GameStateMachineIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.chabomakers.nico;
 
+import static com.chabomakers.nico.gamestate.GameStateMachine.GamePhase.BUYING_RESOURCES;
+
 import com.chabomakers.nico.controllers.GameStateResponse;
 import com.chabomakers.nico.gamestate.AuctionAction.ActionType;
 import com.chabomakers.nico.gamestate.GameStateMachine;
@@ -234,7 +236,7 @@ public class GameStateMachineIntegrationTest {
   }
 
   @Test
-  void auction_secondUserWins() {
+  void auction_secondUserWinsFirstUsersAuction() {
     gameStateMachine.createUser("user1", "red");
     gameStateMachine.createUser("user2", "blue");
     gameStateMachine.createUser("user3", "green");
@@ -316,5 +318,59 @@ public class GameStateMachineIntegrationTest {
     Map<UUID, List<PowerPlantCard>> userPowerPlants =
         gameStateMachine.gameState().userPowerPlants();
     Assertions.assertEquals(userPowerPlants.get(player2Id).size(), 1);
+
+    // Verify: player 1 gets to start a new auction, since this is round 1.
+    gameStateResponse = gameStateMachine.gameState();
+    Assertions.assertEquals(gameStateResponse.currentUser(), player1Id);
+  }
+
+  @Test
+  void auction_skipPreviouslyWonUser() {
+    auction_secondUserWinsFirstUsersAuction();
+
+    GameStateResponse gameStateResponse = gameStateMachine.gameState();
+    Assertions.assertEquals(gameStateResponse.gamePhase(), GamePhase.AUCTION_PICK_PLANT);
+
+    UUID player1Id = gameStateResponse.currentPlayerOrder().get(0);
+    UUID player3Id = gameStateResponse.currentPlayerOrder().get(2);
+
+    PowerPlantCard powerPlantCard = gameStateResponse.actualMarket().get(0);
+    ImmutableAuctionAction auctionAction =
+        ImmutableAuctionAction.builder()
+            .actionType(ActionType.CHOOSE_PLANT)
+            .bid(10)
+            .userId(player1Id)
+            .choosePlantId(powerPlantCard.id())
+            .build();
+    gameStateMachine.performAuctionAction(auctionAction);
+
+    // Verify that we skip the second user, since they won the last auction.
+    gameStateResponse = gameStateMachine.gameState();
+    Truth.assertThat(gameStateResponse.currentUser()).isEqualTo(player3Id);
+
+    auctionAction =
+        ImmutableAuctionAction.builder().actionType(ActionType.PASS).userId(player3Id).build();
+    gameStateMachine.performAuctionAction(auctionAction);
+    Truth.assertThat(gameStateMachine.gameState().userWithHighestPowerplantBid()).isNull();
+
+    // Verify the first user wins the auction. The only remaining auction user should be user 3.
+    gameStateResponse = gameStateMachine.gameState();
+    Truth.assertThat(gameStateResponse.currentUser()).isEqualTo(player3Id);
+    Map<UUID, List<PowerPlantCard>> userPowerPlants =
+        gameStateMachine.gameState().userPowerPlants();
+    Truth.assertThat(userPowerPlants.get(player1Id)).containsExactly(powerPlantCard);
+
+    powerPlantCard = gameStateResponse.actualMarket().get(0);
+    auctionAction =
+        ImmutableAuctionAction.builder()
+            .actionType(ActionType.CHOOSE_PLANT)
+            .bid(10)
+            .userId(player3Id)
+            .choosePlantId(powerPlantCard.id())
+            .build();
+    gameStateMachine.performAuctionAction(auctionAction);
+
+    // Verify: we've finished all auctions.
+    Truth.assertThat(gameStateMachine.gameState().gamePhase()).isEqualTo(BUYING_RESOURCES);
   }
 }


### PR DESCRIPTION
Added a new test case that reproduced the issue from https://github.com/AttwellBrian/nico/issues/22. Then fixed the issue. 

Two relevant changes:
1) Change on Line 91. I was literally forgetting to check if a user had already won a power plant, in the case of a certain state transition
2) I no longer use `auctionNumber` to decide which player will start an auction in the plant purchasing phase. In round 1 of the game, I simply select the first player (by player order) that hasn't won an auction yet. See `updateBidIndexAfterAuctionWon`. This removes the need to keep track of `auctionNumber`. The code for round 2 of the game is only a bit more complex.

Unrelated refactoring:
I also renamed `player` to `user` in my class in the few places I wasn't consistent. While I personally prefer `player` over `user`, I felt it was best to remain consistent in the backend and use `user` everywhere.