### PR TITLE
Fixed bugs making post request to /auction/act fail

### DIFF
--- a/frontend/src/components/PowerPlantMarket.js
+++ b/frontend/src/components/PowerPlantMarket.js
@@ -46,7 +46,7 @@ class PowerPlantMarket extends React.Component {
       return (
         <Col key={index}>
           <PowerPlantCard
-            plantId={plant}
+            plantId={plant.id}
             userId={userProfile.uuid}
             cost={plant.cost}
             type={plant.type}

--- a/frontend/src/functions.js
+++ b/frontend/src/functions.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import * as constants from "./constants";
-import { bake_cookie, delete_cookie } from "sfcookies";
+import { bake_cookie, read_cookie, delete_cookie } from "sfcookies";
 
 function pyth(x, y) {
   if (typeof x !== "number" || typeof y !== "number") return false;
@@ -285,9 +285,17 @@ function apiAuctionAction(actionType, userId, plantId, bid) {
     choosePlantId: plantId,
     bid: bid
   };
+  const axiosConfig = {
+    headers: {
+      // Only certain types qualify as "Simple requests" (and thus do not require the preflight request).
+      // Used for local dev setup. This is needed for local dev setup.
+      // See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests
+      'Content-Type': "text/plain"
+    }
+  };
   axios
     // get data from server
-    .post(constants.serverURL + "/auction/act", auctionData)
+    .post(constants.serverURL + "/auction/act", auctionData, axiosConfig)
     .then(data => {
       console.log(data);
     });

--- a/service/src/main/java/com/chabomakers/nico/DevCorsInterceptor.java
+++ b/service/src/main/java/com/chabomakers/nico/DevCorsInterceptor.java
@@ -17,8 +17,10 @@ class DevCorsInterceptor extends Interceptor {
   @Override
   protected void afterAfter(Request request, Response response) {
     if (request.host().startsWith("localhost:")) {
-      response.header("Access-Control-Allow-Origin", "http://localhost:3000");
-      response.header("Access-Control-Allow-Methods", "*");
+      response.header("Access-Control-Allow-Headers", "*");
+      response.header("Access-Control-Allow-Origin", "*");
+      response.header("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+      response.header("Access-Control-Allow-Credentials", "*");
     }
   }
 }


### PR DESCRIPTION
1. When making a post request with a json body, apparently we need to specify the content-type. Otherwise popular browsers will treat this as a non-simple request, which requires an OPTIONS call when cross-site. Our service doesn't handle the OPTIONS call.
2. Fix passing the plant id into
3. Make the DevCorsInterceptor more permissive. *This wasn't necessary*. But this will save us time debugging next time we see a CORS issue.

For https://github.com/AttwellBrian/nico/issues/24