### PR TITLE
Different build environments

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "yarn install && react-scripts build && rm -rf dist && mkdir -p dist && cp -r build/ dist/release",
+    "build": "yarn install && REACT_APP_STAGE=prod react-scripts build && rm -rf dist && mkdir -p dist && cp -r build/ dist/release",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,4 +1,4 @@
-const serverURL = "http://localhost:8080";
+const serverURL = process.env.REACT_APP_STAGE === "prod" ? "https://nico-service-pwe5kqqlfa-uc.a.run.app" : "http://localhost:8080";
 
 const emptyGameStateSchema = {
   players: {},


### PR DESCRIPTION
When you run `yarn start`, the frontend that can be viewed at localhost:3000 makes backend requests against the localhost:8080.

When you build a prod build with `yarn build`, that version of the frontend makes requests against https://nico-service-pwe5kqqlfa-uc.a.run.app/

Tests:
* Ran `yarn start`. Verified it's requests hit the expected port.
* Deployed to production using the release pipeline. Verified that https://nico-service-pwe5kqqlfa-uc.a.run.app/ works as expected.

<img width="876" alt="Screen Shot 2020-01-07 at 1 50 08 AM" src="https://user-images.githubusercontent.com/549900/71886200-a236b500-30f0-11ea-9cb1-c20882d1d69a.png">
